### PR TITLE
docs: fix modeling guide link

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,4 +16,4 @@ Semantic Notes is organized into three main layers:
 
 3. **Tooling** — Located in the `scripts/` and `tests/` folders. These contain scripts for dataset export/import, context generation and automated tests. Continuous integration is configured via GitHub Actions in `.github/workflows/`.
 
-Refer to `MODELNG_GUIDE.md` for modeling conventions and `AI_DEV.md` for AI assistance policy.
+Refer to `MODELING_GUIDE.md` for modeling conventions and `AI_DEV.md` for AI assistance policy.

--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ pnpm run build                # produces static assets into `dist/`
 | `scripts/` | Build/validation helpers |
 | `tests/` | Vitest tests and SPARQL invariants |
 
-For more information see `SPECS.md`, `MODELNG_GUIDE.md` and `AI_DEV.md`.
+For more information see `SPECS.md`, `MODELING_GUIDE.md` and `AI_DEV.md`.


### PR DESCRIPTION
## Summary
- fix README and ARCHITECTURE references to `MODELING_GUIDE.md`

## Testing
- `npx -y markdown-link-check README.md`
- `npx -y markdown-link-check ARCHITECTURE.md`
- `pnpm test` *(fails: No package.json found)*

------
https://chatgpt.com/codex/tasks/task_e_689fa1efc3848325842675b9eb871d0f