### PR TITLE
docs: add placeholder READMEs for core directories

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,8 @@
+# App
+
+This directory will hold the application's source code.
+
+Expected structure:
+- `src/` – core application modules.
+
+TODO: implement the application.

--- a/content/README.md
+++ b/content/README.md
@@ -1,0 +1,8 @@
+# Content
+
+This directory will store domain content and ontologies.
+
+Expected structure:
+- `ontology/` – OWL and SKOS resources.
+
+TODO: add content assets.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,8 @@
+# Scripts
+
+Utility scripts for development and validation tasks.
+
+Expected files:
+- `run-shacl.mjs` – runs SHACL validation.
+
+TODO: provide script implementations.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,8 @@
+# Tests
+
+Automated test suites ensuring project quality.
+
+Expected structure:
+- `unit/` – unit tests for individual modules.
+
+TODO: write test cases.


### PR DESCRIPTION
## Summary
- add README placeholders for `app`, `content`, `scripts`, and `tests`
- document expected sub-structure and note that implementation is pending

## Testing
- `pnpm test` *(fails: No package.json (or package.yaml, or package.json5) was found)*

------
https://chatgpt.com/codex/tasks/task_e_689faa281b408325bf16d25a0cff5770