### PR TITLE
docs: mention stable base IRIs in security overview

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,6 +9,7 @@ Semantic Notes is a client-side application that synchronizes data via Firebase.
 3. **Environment variables**: API keys and other secrets are provided via environment variables (`.env`). Never commit secrets to the repository. An example `.env.example` file is provided.
 4. **Offline persistence**: Firestore is used with offline persistence enabled; data is cached locally and synced when connectivity is restored. No sensitive data is transmitted to external APIs by default.
 5. **AI services**: Cloud AI integrations are opt-in and disabled by default. When enabled, they include provenance metadata and respect configured budgets.
+6. **Stable base IRIs**: Use a stable, redirectable base IRI (e.g., a `w3id.org` prefix) to protect consumers from link rot and support long-term IRI persistence.
 
 ## Reporting vulnerabilities
 


### PR DESCRIPTION
## Summary
- advise using stable, redirectable base IRIs such as `w3id.org` to prevent link rot and ensure long-term IRI persistence

## Testing
- `pnpm test` *(fails: ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND No package.json found)*

------
https://chatgpt.com/codex/tasks/task_e_689fe77e720883258a398b3b8aa443a8