### PR TITLE
fix: use type-only import for FormEvent

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, FormEvent } from 'react';
+import { useState, type FormEvent } from 'react';
 import { Routes, Route } from 'react-router-dom';
 
 function Home() {


### PR DESCRIPTION
## Summary
- use type-only import for `FormEvent` to satisfy verbatim module syntax

## Testing
- `pnpm --dir app build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a418643b3c8325983fd1e0aedf25e0