### PR TITLE
feat: list notes and suggest triple terms

### DIFF
--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import App from './App';
@@ -15,15 +15,22 @@ describe('App', () => {
     const noteInput = screen.getByLabelText(/note/i);
     const subjectInput = screen.getByLabelText(/subject/i);
     const predicateInput = screen.getByLabelText(/predicate/i);
-    const objectInput = screen.getByLabelText(/object/i);
+    const objectInput = screen.getByLabelText(/^object$/i);
+    const objectTypeSelect = screen.getByLabelText(/object type/i);
 
     await userEvent.type(noteInput, 'Example note');
     await userEvent.type(subjectInput, 'ex:Subject');
     await userEvent.type(predicateInput, 'ex:predicate');
     await userEvent.type(objectInput, 'ex:Object');
+    await userEvent.selectOptions(objectTypeSelect, 'class');
     await userEvent.click(screen.getByRole('button', { name: /save/i }));
 
     expect(screen.getByText('Example note')).toBeTruthy();
-    expect(screen.getByText('ex:Subject ex:predicate ex:Object')).toBeTruthy();
+    expect(
+      screen.getByText('ex:Subject ex:predicate ex:Object (class)')
+    ).toBeTruthy();
+
+    const subjectOptions = screen.getByTestId('subject-options');
+    expect(subjectOptions.querySelector('option[value="ex:Subject"]')).toBeTruthy();
   });
 });

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -6,11 +6,23 @@ function Home() {
   const [subject, setSubject] = useState('');
   const [predicate, setPredicate] = useState('');
   const [object, setObject] = useState('');
+  const [objectType, setObjectType] = useState('data');
   const [error, setError] = useState('');
-  const [saved, setSaved] =
-    useState<{ note: string; triple: { subject: string; predicate: string; object: string } } | null>(
-      null,
-    );
+  const [notes, setNotes] =
+    useState<
+      Array<{
+        note: string;
+        triple: {
+          subject: string;
+          predicate: string;
+          object: string;
+          objectType: string;
+        };
+      }>
+    >([]);
+  const [subjects, setSubjects] = useState<string[]>([]);
+  const [predicates, setPredicates] = useState<string[]>([]);
+  const [objects, setObjects] = useState<string[]>([]);
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
@@ -19,11 +31,15 @@ function Home() {
       return;
     }
     setError('');
-    setSaved({ note, triple: { subject, predicate, object } });
+    const newNote = { note, triple: { subject, predicate, object, objectType } };
+    setNotes((prev) => [...prev, newNote]);
     setNote('');
     setSubject('');
     setPredicate('');
     setObject('');
+    setSubjects((prev) => Array.from(new Set([...prev, subject])));
+    setPredicates((prev) => Array.from(new Set([...prev, predicate])));
+    setObjects((prev) => Array.from(new Set([...prev, object])));
   };
 
   return (
@@ -36,26 +52,67 @@ function Home() {
         </label>
         <label>
           Subject
-          <input value={subject} onChange={(e) => setSubject(e.target.value)} />
+          <input
+            list="subject-options"
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+          />
+          <datalist id="subject-options" data-testid="subject-options">
+            {subjects.map((s) => (
+              <option key={s} value={s} />
+            ))}
+          </datalist>
         </label>
         <label>
           Predicate
-          <input value={predicate} onChange={(e) => setPredicate(e.target.value)} />
+          <input
+            list="predicate-options"
+            value={predicate}
+            onChange={(e) => setPredicate(e.target.value)}
+          />
+          <datalist id="predicate-options" data-testid="predicate-options">
+            {predicates.map((p) => (
+              <option key={p} value={p} />
+            ))}
+          </datalist>
         </label>
         <label>
           Object
-          <input value={object} onChange={(e) => setObject(e.target.value)} />
+          <input
+            list="object-options"
+            value={object}
+            onChange={(e) => setObject(e.target.value)}
+          />
+          <datalist id="object-options" data-testid="object-options">
+            {objects.map((o) => (
+              <option key={o} value={o} />
+            ))}
+          </datalist>
+        </label>
+        <label>
+          Object Type
+          <select value={objectType} onChange={(e) => setObjectType(e.target.value)}>
+            <option value="data">Data</option>
+            <option value="class">Class</option>
+            <option value="other">Other</option>
+          </select>
         </label>
         <button type="submit">Save</button>
       </form>
       {error && <p role="alert">{error}</p>}
-      {saved && (
+      {notes.length > 0 && (
         <div>
           <h2>Saved</h2>
-          <pre>{saved.note}</pre>
-          <pre>
-            {saved.triple.subject} {saved.triple.predicate} {saved.triple.object}
-          </pre>
+          <ul>
+            {notes.map((n, i) => (
+              <li key={i}>
+                <pre>{n.note}</pre>
+                <pre>
+                  {n.triple.subject} {n.triple.predicate} {n.triple.object} ({n.triple.objectType})
+                </pre>
+              </li>
+            ))}
+          </ul>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- allow entering object type and smart suggestions for subject, predicate, and object terms
- display all saved notes along with their triples

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a439b6bed48325aeddde57a58d1df3