### PR TITLE
fix: remove unused test import

### DIFF
--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import App from './App';


### PR DESCRIPTION
## Summary
- remove unused `within` import from `App.test.tsx` that caused TypeScript build to fail

## Testing
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a44058fc54832593bac28d0978e188