### PR TITLE
Clarify note attachment in home interface

### DIFF
--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -12,7 +12,8 @@ describe('App', () => {
       </MemoryRouter>
     );
 
-    const noteInput = screen.getByLabelText(/note/i);
+    const noteInput = screen.getByLabelText(/^note$/i);
+    const noteTargetSelect = screen.getByLabelText(/note target/i);
     const structureInput = screen.getByLabelText(/semantic structure/i);
     const subjectInput = screen.getByLabelText(/subject/i);
     const predicateInput = screen.getByLabelText(/predicate/i);
@@ -25,9 +26,10 @@ describe('App', () => {
     await userEvent.type(predicateInput, 'ex:predicate');
     await userEvent.type(objectInput, 'ex:Object');
     await userEvent.selectOptions(objectTypeSelect, 'class');
+    await userEvent.selectOptions(noteTargetSelect, 'predicate');
     await userEvent.click(screen.getByRole('button', { name: /save/i }));
 
-    expect(screen.getByText('Example note')).toBeTruthy();
+    expect(screen.getByText('Note on predicate: Example note')).toBeTruthy();
     expect(
       screen.getByText('ex:Subject ex:predicate ex:Object (class)')
     ).toBeTruthy();

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -3,6 +3,9 @@ import { Routes, Route } from 'react-router-dom';
 
 function Home() {
   const [note, setNote] = useState('');
+  const [noteTarget, setNoteTarget] = useState<
+    'subject' | 'predicate' | 'object' | 'triple'
+  >('triple');
   const [structure, setStructure] = useState('');
   const [subject, setSubject] = useState('');
   const [predicate, setPredicate] = useState('');
@@ -13,6 +16,7 @@ function Home() {
     useState<
       Array<{
         note: string;
+        noteTarget: 'subject' | 'predicate' | 'object' | 'triple';
         structure: string;
         triple: {
           subject: string;
@@ -33,9 +37,15 @@ function Home() {
       return;
     }
     setError('');
-    const newNote = { note, structure, triple: { subject, predicate, object, objectType } };
+    const newNote = {
+      note,
+      noteTarget,
+      structure,
+      triple: { subject, predicate, object, objectType },
+    };
     setNotes((prev) => [...prev, newNote]);
     setNote('');
+    setNoteTarget('triple');
     setStructure('');
     setSubject('');
     setPredicate('');
@@ -52,6 +62,18 @@ function Home() {
         <label>
           Note
           <textarea value={note} onChange={(e) => setNote(e.target.value)} />
+        </label>
+        <label>
+          Note Target
+          <select
+            value={noteTarget}
+            onChange={(e) => setNoteTarget(e.target.value)}
+          >
+            <option value="triple">Triple</option>
+            <option value="subject">Subject</option>
+            <option value="predicate">Predicate</option>
+            <option value="object">Object</option>
+          </select>
         </label>
         <label>
           Semantic Structure
@@ -116,11 +138,15 @@ function Home() {
           <ul>
             {notes.map((n, i) => (
               <li key={i}>
-                <pre>{n.note}</pre>
-                {n.structure && <pre>{n.structure}</pre>}
                 <pre>
                   {n.triple.subject} {n.triple.predicate} {n.triple.object} ({n.triple.objectType})
                 </pre>
+                {n.note && (
+                  <pre>
+                    Note on {n.noteTarget}: {n.note}
+                  </pre>
+                )}
+                {n.structure && <pre>{n.structure}</pre>}
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- allow specifying what part of a triple a note describes
- show saved triples with associated notes and targets
- update tests for note target selection

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4558331ac8325bdd099cc8b4bf8d7