### PR TITLE
feat: improve triple editor UI

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -72,9 +72,10 @@ function Home() {
   };
 
   return (
-    <div>
-      <h1>Home</h1>
-      <form onSubmit={handleSubmit}>
+    <div className="app-container">
+      <section className="form-section">
+        <h1>Semantic Notes</h1>
+        <form onSubmit={handleSubmit}>
         <label>
           Note
           <textarea value={note} onChange={(e) => setNote(e.target.value)} />
@@ -145,29 +146,62 @@ function Home() {
             <option value="other">Other</option>
           </select>
         </label>
-        <button type="submit">Save</button>
-      </form>
-      {error && <p role="alert">{error}</p>}
-      {notes.length > 0 && (
-        <div>
-          <h2>Saved</h2>
-          <ul>
-            {notes.map((n, i) => (
-              <li key={i}>
-                <pre>
-                  {n.triple.subject} {n.triple.predicate} {n.triple.object} ({n.triple.objectType})
-                </pre>
-                {n.note && (
+          <button type="submit">Save</button>
+        </form>
+        {error && (
+          <p className="error" role="alert">
+            {error}
+          </p>
+        )}
+      </section>
+      <section className="data-section">
+        {subjects.length > 0 && (
+          <div>
+            <h2>Registered Subjects</h2>
+            <ul className="registered-list">
+              {subjects.map((s) => (
+                <li key={s}>
+                  <button type="button" onClick={() => setSubject(s)}>
+                    {s}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {predicates.length > 0 && (
+          <div>
+            <h2>Registered Predicates</h2>
+            <ul className="registered-list">
+              {predicates.map((p) => (
+                <li key={p}>
+                  <button type="button" onClick={() => setPredicate(p)}>
+                    {p}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {notes.length > 0 && (
+          <div>
+            <h2>Registered Triples</h2>
+            <ul className="note-list">
+              {notes.map((n, i) => (
+                <li key={i} className="note-card">
                   <pre>
-                    Note on {n.noteTarget}: {n.note}
+                    {n.triple.subject} {n.triple.predicate} {n.triple.object} ({n.triple.objectType})
                   </pre>
-                )}
-                {n.structure && <pre>{n.structure}</pre>}
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
+                  {n.note && (
+                    <pre>Note on {n.noteTarget}: {n.note}</pre>
+                  )}
+                  {n.structure && <pre>{n.structure}</pre>}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </section>
     </div>
   );
 }

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -1,38 +1,72 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  --background: #f0f4f8;
+  --primary: #4a90e2;
+  --card-bg: #ffffff;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
+  color: #213547;
+  background-color: var(--background);
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  background-color: var(--background);
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+.app-container {
+  display: flex;
+  gap: 2rem;
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+.form-section {
+  flex: 1;
+  background: var(--card-bg);
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.data-section {
+  flex: 1;
+}
+
+.registered-list,
+.note-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.registered-list button {
+  background: var(--card-bg);
+  border: 1px solid var(--primary);
+  color: var(--primary);
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.note-card {
+  background: var(--card-bg);
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 0.5rem;
+}
+
+.error {
+  color: #c00;
+  margin-top: 1rem;
 }
 
 button {
@@ -42,27 +76,12 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: var(--primary);
+  color: #fff;
   cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  transition: opacity 0.25s;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+button:hover {
+  opacity: 0.85;
 }


### PR DESCRIPTION
## Summary
- style triple entry form with colors and layout
- list registered subjects/predicates to reuse when creating triples
- display saved triples in cards

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a483fbd0488325ac303655a2b5245b