### PR TITLE
Fix note target union type and clarify agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ Follow these rules when working on this repository:
 - **Keep OWL and SKOS in sync**: update parallel ontology representations together.
 - **Run `pnpm test` before submitting pull requests**.
 - **Avoid cross-module edits**: confine changes to a single module at a time.
+- **Cast form values to literal types**: when updating React state from form inputs, cast `e.target.value` to the expected literal union type (e.g. `as NoteTarget`) to prevent TypeScript build errors.
 - **Review [SPECS.md](SPECS.md) and [TESTING.md](TESTING.md)**: avoid removing existing features or invariants; coordinate with maintainers if a feature must be deprecated.
 
 Quick references:

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2,11 +2,11 @@ import { useState, type FormEvent } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import { expandCurie } from './namespaces';
 
+type NoteTarget = 'subject' | 'predicate' | 'object' | 'triple';
+
 function Home() {
   const [note, setNote] = useState('');
-  const [noteTarget, setNoteTarget] = useState<
-    'subject' | 'predicate' | 'object' | 'triple'
-  >('triple');
+  const [noteTarget, setNoteTarget] = useState<NoteTarget>('triple');
   const [structure, setStructure] = useState('');
   const [subject, setSubject] = useState('');
   const [predicate, setPredicate] = useState('');
@@ -84,7 +84,7 @@ function Home() {
           Note Target
           <select
             value={noteTarget}
-            onChange={(e) => setNoteTarget(e.target.value)}
+            onChange={(e) => setNoteTarget(e.target.value as NoteTarget)}
           >
             <option value="triple">Triple</option>
             <option value="subject">Subject</option>


### PR DESCRIPTION
## Summary
- Cast `NoteTarget` state updates to literal union to satisfy TypeScript
- Document guideline for agents to cast form values to literal types to avoid build errors

## Testing
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a4e721e0d883259a7eb6aa67fa2df3