### PR TITLE
feat: allow adding notes from triple parts

### DIFF
--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -34,9 +34,16 @@ describe('App', () => {
     await userEvent.click(screen.getByRole('button', { name: /save/i }));
 
     expect(screen.getByText('Note on predicate: Example note')).toBeTruthy();
-    expect(
-      screen.getByText('ex:Subject ex:predicate ex:Object (class)')
-    ).toBeTruthy();
+    expect(screen.getByTitle('Add note about this subject').textContent).toBe(
+      'ex:Subject'
+    );
+    expect(screen.getByTitle('Add note about this predicate').textContent).toBe(
+      'ex:predicate'
+    );
+    expect(screen.getByTitle('Add note about this object').textContent).toBe(
+      'ex:Object'
+    );
+    expect(screen.getByText('(class)')).toBeTruthy();
     expect(screen.getByText('{"type":"Example"}')).toBeTruthy();
 
     const subjectOptions = screen.getByTestId('subject-options');
@@ -61,11 +68,15 @@ describe('App', () => {
     await userEvent.selectOptions(objectTypeSelect, 'class');
     await userEvent.click(screen.getByRole('button', { name: /save/i }));
 
+    expect(screen.getByTitle('Add note about this subject').textContent).toBe(
+      'ex:Thing'
+    );
     expect(
-      screen.getByText(
-        'ex:Thing http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://www.w3.org/2004/02/skos/core#Concept (class)'
-      )
-    ).toBeTruthy();
+      screen.getByTitle('Add note about this predicate').textContent
+    ).toBe('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+    expect(screen.getByTitle('Add note about this object').textContent).toBe(
+      'http://www.w3.org/2004/02/skos/core#Concept'
+    );
   });
 
   it('provides guidance through tooltips', () => {
@@ -77,5 +88,38 @@ describe('App', () => {
 
     expect(screen.getByLabelText(/note target/i).getAttribute('title')).toBeTruthy();
     expect(screen.getByLabelText(/subject/i).getAttribute('title')).toBeTruthy();
+  });
+
+  it('prefills form fields when triple parts are clicked', async () => {
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    );
+
+    const subjectInput = screen.getByLabelText(/subject/i);
+    const predicateInput = screen.getByLabelText(/predicate/i);
+    const objectInput = screen.getByLabelText(/^object$/i);
+
+    await userEvent.type(subjectInput, 'ex:S1');
+    await userEvent.type(predicateInput, 'ex:p1');
+    await userEvent.type(objectInput, 'ex:O1');
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    const subjectBtn = screen.getByTitle('Add note about this subject');
+    await userEvent.click(subjectBtn);
+
+    expect((screen.getByLabelText(/subject/i) as HTMLInputElement).value).toBe(
+      'ex:S1'
+    );
+    expect((screen.getByLabelText(/predicate/i) as HTMLInputElement).value).toBe(
+      'ex:p1'
+    );
+    expect((screen.getByLabelText(/^object$/i) as HTMLInputElement).value).toBe(
+      'ex:O1'
+    );
+    expect(
+      (screen.getByLabelText(/note target/i) as HTMLSelectElement).value
+    ).toBe('subject');
   });
 });

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -71,6 +71,22 @@ function Home() {
     );
   };
 
+  const prefillFromTriple = (
+    triple: {
+      subject: string;
+      predicate: string;
+      object: string;
+      objectType: string;
+    },
+    target: NoteTarget
+  ) => {
+    setSubject(triple.subject);
+    setPredicate(triple.predicate);
+    setObject(triple.object);
+    setObjectType(triple.objectType);
+    setNoteTarget(target);
+  };
+
   return (
     <div className="app-container">
       <section className="form-section">
@@ -207,9 +223,41 @@ function Home() {
             <ul className="note-list">
               {notes.map((n, i) => (
                 <li key={i} className="note-card">
-                  <pre>
-                    {n.triple.subject} {n.triple.predicate} {n.triple.object} ({n.triple.objectType})
-                  </pre>
+                  <div className="triple-display">
+                    <button
+                      type="button"
+                      className="triple-part-button"
+                      title="Add note about this subject"
+                      onClick={() => prefillFromTriple(n.triple, 'subject')}
+                    >
+                      {n.triple.subject}
+                    </button>
+                    <button
+                      type="button"
+                      className="triple-part-button"
+                      title="Add note about this predicate"
+                      onClick={() => prefillFromTriple(n.triple, 'predicate')}
+                    >
+                      {n.triple.predicate}
+                    </button>
+                    <button
+                      type="button"
+                      className="triple-part-button"
+                      title="Add note about this object"
+                      onClick={() => prefillFromTriple(n.triple, 'object')}
+                    >
+                      {n.triple.object}
+                    </button>
+                    <span>({n.triple.objectType})</span>
+                  </div>
+                  <button
+                    type="button"
+                    className="triple-note-button"
+                    title="Add note about this triple"
+                    onClick={() => prefillFromTriple(n.triple, 'triple')}
+                  >
+                    Add note
+                  </button>
                   {n.note && (
                     <pre>Note on {n.noteTarget}: {n.note}</pre>
                   )}

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -64,6 +64,32 @@ body {
   padding: 0.5rem;
 }
 
+.triple-display {
+  display: flex;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.triple-part-button {
+  background: none;
+  border: none;
+  color: var(--primary);
+  cursor: pointer;
+  padding: 0;
+  font: inherit;
+  text-decoration: underline;
+}
+
+.triple-part-button:hover {
+  text-decoration: none;
+}
+
+.triple-note-button {
+  margin-bottom: 0.5rem;
+}
+
 .error {
   color: #c00;
   margin-top: 1rem;


### PR DESCRIPTION
## Summary
- make each triple component clickable to prefill note form and target
- style triple display and note buttons
- test triple-part clicks for form prefilling

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a58e037a3c8325abf4d42f3a54b7ae