### PR TITLE
Skip Firestore calls during tests

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -32,6 +32,7 @@ function Home() {
   const [subjects, setSubjects] = useState<string[]>([]);
   const [predicates, setPredicates] = useState<string[]>([]);
   const [objects, setObjects] = useState<string[]>([]);
+  const isTestEnv = import.meta.env.MODE === 'test';
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
@@ -56,7 +57,9 @@ function Home() {
       },
     };
     setNotes((prev) => [...prev, newNote]);
-    void addDoc(collection(db, 'notes'), newNote).catch(console.error);
+    if (!isTestEnv) {
+      void addDoc(collection(db, 'notes'), newNote).catch(console.error);
+    }
     setNote('');
     setNoteTarget('triple');
     setStructure('');
@@ -91,6 +94,7 @@ function Home() {
   };
 
   useEffect(() => {
+    if (isTestEnv) return;
     const loadNotes = async () => {
       try {
         const snapshot = await getDocs(collection(db, 'notes'));
@@ -110,7 +114,7 @@ function Home() {
       }
     };
     void loadNotes();
-  }, []);
+  }, [isTestEnv]);
 
   return (
     <div className="app-container">


### PR DESCRIPTION
## Summary
- Avoid reading/writing Firestore when running in test mode
- Prevent duplicate notes from persistence during tests

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a59da3ef7083258765694588c6121d