### PR TITLE
feat: make triple visualization interactive

### DIFF
--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -131,4 +131,37 @@ describe('App', () => {
       (screen.getByLabelText(/note target/i) as HTMLSelectElement).value
     ).toBe('subject');
   });
+
+  it('prefills form fields when visualization edge is clicked', async () => {
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    );
+
+    const subjectInput = screen.getByLabelText(/subject/i);
+    const predicateInput = screen.getByLabelText(/predicate/i);
+    const objectInput = screen.getByLabelText(/^object$/i);
+
+    await userEvent.type(subjectInput, 'ex:Vs');
+    await userEvent.type(predicateInput, 'ex:Vp');
+    await userEvent.type(objectInput, 'ex:Vo');
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    const edge = screen.getByTestId('triple-edge-0');
+    await userEvent.click(edge);
+
+    expect((screen.getByLabelText(/subject/i) as HTMLInputElement).value).toBe(
+      'ex:Vs'
+    );
+    expect((screen.getByLabelText(/predicate/i) as HTMLInputElement).value).toBe(
+      'ex:Vp'
+    );
+    expect((screen.getByLabelText(/^object$/i) as HTMLInputElement).value).toBe(
+      'ex:Vo'
+    );
+    expect(
+      (screen.getByLabelText(/note target/i) as HTMLSelectElement).value
+    ).toBe('triple');
+  });
 });

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -299,7 +299,10 @@ function Home() {
           </div>
         )}
         {notes.length > 0 && (
-          <TripleVisualization triples={notes.map((n) => n.triple)} />
+          <TripleVisualization
+            triples={notes.map((n) => n.triple)}
+            onTripleClick={(t) => prefillFromTriple(t, 'triple')}
+          />
         )}
       </section>
     </div>

--- a/app/src/TripleVisualization.tsx
+++ b/app/src/TripleVisualization.tsx
@@ -2,13 +2,18 @@ export type Triple = {
   subject: string;
   predicate: string;
   object: string;
+  objectType: 'data' | 'class' | 'other';
 };
 
 interface TripleVisualizationProps {
   triples: Triple[];
+  onTripleClick?: (triple: Triple) => void;
 }
 
-export default function TripleVisualization({ triples }: TripleVisualizationProps) {
+export default function TripleVisualization({
+  triples,
+  onTripleClick,
+}: TripleVisualizationProps) {
   const nodeIds = Array.from(
     new Set(triples.flatMap((t) => [t.subject, t.object]))
   );
@@ -22,6 +27,7 @@ export default function TripleVisualization({ triples }: TripleVisualizationProp
     source: nodeMap.get(t.subject)!,
     target: nodeMap.get(t.object)!,
     label: t.predicate,
+    triple: t,
   }));
   const width = Math.min(5, nodeIds.length) * 150 + 100;
   const height = Math.ceil(nodeIds.length / 5) * 100 + 100;
@@ -31,7 +37,12 @@ export default function TripleVisualization({ triples }: TripleVisualizationProp
       <h2>Triple Visualization</h2>
       <svg width={width} height={height} data-testid="triple-visualization">
         {edges.map((e, i) => (
-          <g key={i}>
+          <g
+            key={i}
+            className="triple-edge"
+            data-testid={`triple-edge-${i}`}
+            onClick={() => onTripleClick?.(e.triple)}
+          >
             <line
               x1={e.source.x}
               y1={e.source.y}

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -90,6 +90,10 @@ body {
   margin-bottom: 0.5rem;
 }
 
+.triple-edge {
+  cursor: pointer;
+}
+
 .error {
   color: #c00;
   margin-top: 1rem;


### PR DESCRIPTION
## Summary
- make triple visualization edges clickable and expose `onTripleClick`
- wire visualization to form to prefill triples
- add test and pointer cursor styling for interactive edges

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a59f6dea948325bf9e67c759f73312