### PR TITLE
feat: store triples as N-Quads via RDFJS

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -14,7 +14,8 @@
     "firebase": "^12.1.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-router-dom": "^7.8.1"
+    "react-router-dom": "^7.8.1",
+    "n3": "^1.26.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
@@ -31,6 +32,7 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
     "vite": "^7.1.2",
-    "vitest": "^1.6.0"
+    "vitest": "^1.6.0",
+    "@rdfjs/types": "^2.0.1"
   }
 }

--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -19,18 +19,16 @@ describe('App', () => {
     const subjectInput = screen.getByLabelText(/subject/i);
     const predicateInput = screen.getByLabelText(/predicate/i);
     const objectInput = screen.getByLabelText(/^object$/i);
-    const objectTypeSelect = screen.getByLabelText(/object type/i);
 
     await userEvent.type(subjectInput, 'ex:Subject');
     await userEvent.type(predicateInput, 'ex:predicate');
     await userEvent.type(objectInput, 'ex:Object');
-    await userEvent.selectOptions(objectTypeSelect, 'class');
     await userEvent.click(screen.getByRole('button', { name: /save/i }));
 
     expect(screen.getByTitle('Use subject').textContent).toBe('ex:Subject');
     expect(screen.getByTitle('Use predicate').textContent).toBe('ex:predicate');
     expect(screen.getByTitle('Use object').textContent).toBe('ex:Object');
-    expect(screen.getByText('(class)')).toBeTruthy();
+    expect(screen.getByText('(NamedNode)')).toBeTruthy();
 
     const subjectOptions = screen.getByTestId('subject-options');
     expect(subjectOptions.querySelector('option[value="ex:Subject"]')).toBeTruthy();
@@ -50,12 +48,10 @@ describe('App', () => {
     const subjectInput = screen.getByLabelText(/subject/i);
     const predicateInput = screen.getByLabelText(/predicate/i);
     const objectInput = screen.getByLabelText(/^object$/i);
-    const objectTypeSelect = screen.getByLabelText(/object type/i);
 
     await userEvent.type(subjectInput, 'ex:Thing');
     await userEvent.type(predicateInput, 'rdf:type');
     await userEvent.type(objectInput, 'skos:Concept');
-    await userEvent.selectOptions(objectTypeSelect, 'class');
     await userEvent.click(screen.getByRole('button', { name: /save/i }));
 
     const predicateButtons = screen.getAllByTitle('Use predicate');

--- a/app/src/TripleVisualization.tsx
+++ b/app/src/TripleVisualization.tsx
@@ -1,13 +1,8 @@
-export type Triple = {
-  subject: string;
-  predicate: string;
-  object: string;
-  objectType: 'data' | 'class' | 'other';
-};
+import type { Quad } from '@rdfjs/types';
 
 interface TripleVisualizationProps {
-  triples: Triple[];
-  onTripleClick?: (triple: Triple) => void;
+  triples: Quad[];
+  onTripleClick?: (triple: Quad) => void;
 }
 
 export default function TripleVisualization({
@@ -15,7 +10,7 @@ export default function TripleVisualization({
   onTripleClick,
 }: TripleVisualizationProps) {
   const nodeIds = Array.from(
-    new Set(triples.flatMap((t) => [t.subject, t.object]))
+    new Set(triples.flatMap((t) => [t.subject.value, t.object.value]))
   );
   const nodes = nodeIds.map((id, idx) => ({
     id,
@@ -24,9 +19,9 @@ export default function TripleVisualization({
   }));
   const nodeMap = new Map(nodes.map((n) => [n.id, n]));
   const edges = triples.map((t) => ({
-    source: nodeMap.get(t.subject)!,
-    target: nodeMap.get(t.object)!,
-    label: t.predicate,
+    source: nodeMap.get(t.subject.value)!,
+    target: nodeMap.get(t.object.value)!,
+    label: t.predicate.value,
     triple: t,
   }));
   const width = Math.min(5, nodeIds.length) * 150 + 100;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       firebase:
         specifier: ^12.1.0
         version: 12.1.0
+      n3:
+        specifier: ^1.26.0
+        version: 1.26.0
       react:
         specifier: ^19.1.1
         version: 19.1.1
@@ -54,6 +57,9 @@ importers:
       '@eslint/js':
         specifier: ^9.33.0
         version: 9.33.0
+      '@rdfjs/types':
+        specifier: ^2.0.1
+        version: 2.0.1
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -95,7 +101,7 @@ importers:
         version: 7.1.2(@types/node@24.3.0)
       vitest:
         specifier: ^1.6.0
-        version: 1.6.1(@types/node@24.3.0)(@vitest/ui@3.2.4)(jsdom@26.1.0)
+        version: 1.6.1(@types/node@24.3.0)(@vitest/ui@3.2.4(vitest@3.2.4))(jsdom@26.1.0)
 
 packages:
 
@@ -9991,7 +9997,7 @@ snapshots:
       '@types/node': 24.3.0
       fsevents: 2.3.3
 
-  vitest@1.6.1(@types/node@24.3.0)(@vitest/ui@3.2.4)(jsdom@26.1.0):
+  vitest@1.6.1(@types/node@24.3.0)(@vitest/ui@3.2.4(vitest@3.2.4))(jsdom@26.1.0):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1


### PR DESCRIPTION
## Summary
- use N3 DataFactory/Writer/Parser to handle triples as RDFJS quads
- drop object type field and infer term type from RDF terms
- adjust visualization, tests, and dependencies for N-Quads storage

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5ff086db08325b9212483a5e93ce1