### PR TITLE
Add concept tree for SKOS hierarchy

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -15,7 +15,8 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.1",
-    "n3": "^1.26.0"
+    "n3": "^1.26.0",
+    "@comunica/query-sparql": "^4.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import App from './App';
@@ -163,5 +163,32 @@ describe('App', () => {
 
     expect(screen.queryByText('ex:S2')).toBeNull();
     expect(subjectOptions.querySelector('option[value="ex:S2"]')).toBeFalsy();
+  });
+
+  it('renders concept tree and selects concepts', async () => {
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    );
+
+    const subjectInput = screen.getByLabelText(/subject/i);
+    const predicateInput = screen.getByLabelText(/predicate/i);
+    const objectInput = screen.getByLabelText(/^object$/i);
+
+    await userEvent.type(subjectInput, 'ex:Child');
+    await userEvent.type(predicateInput, 'skos:broader');
+    await userEvent.type(objectInput, 'ex:Parent');
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    const tree = await screen.findByTestId('concept-tree');
+    const childBtn = within(tree).getByRole('button', { name: 'ex:Child' });
+    await userEvent.click(childBtn);
+
+    expect((screen.getByLabelText(/subject/i) as HTMLInputElement).value).toBe(
+      'ex:Child'
+    );
+    const viz = screen.getByTestId('triple-visualization');
+    expect(viz.querySelector('circle[fill="yellow"]')).toBeTruthy();
   });
 });

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -12,6 +12,7 @@ import {
 import { db } from './firebase';
 import TripleVisualization from './TripleVisualization';
 import EntityForm from './EntityForm';
+import ConceptTree from './ConceptTree';
 import { DataFactory, Parser, Writer } from 'n3';
 import type { Quad } from '@rdfjs/types';
 
@@ -31,6 +32,7 @@ function Home() {
   const [predicates, setPredicates] = useState<string[]>([]);
   const [objects, setObjects] = useState<string[]>([]);
   const [editingId, setEditingId] = useState<string | null>(null);
+  const [focusedConcept, setFocusedConcept] = useState<string | null>(null);
   const isTestEnv = import.meta.env.MODE === 'test';
 
   const serializeQuad = (q: Quad): Promise<string> => {
@@ -273,9 +275,19 @@ function Home() {
           </div>
         )}
         {triples.length > 0 && (
+          <ConceptTree
+            triples={triples.map((t) => t.quad)}
+            onSelect={(iri) => {
+              setSubject(iri);
+              setFocusedConcept(iri);
+            }}
+          />
+        )}
+        {triples.length > 0 && (
           <TripleVisualization
             triples={triples.map((t) => t.quad)}
             onTripleClick={(t) => prefillFromTriple(t)}
+            focusNode={focusedConcept ?? undefined}
           />
         )}
       </section>

--- a/app/src/ConceptTree.tsx
+++ b/app/src/ConceptTree.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import { Store } from 'n3';
+import type { Quad } from '@rdfjs/types';
+import { QueryEngine } from '@comunica/query-sparql';
+
+interface ConceptTreeProps {
+  triples: Quad[];
+  onSelect?: (iri: string) => void;
+}
+
+interface Tree {
+  [parent: string]: string[];
+}
+
+export default function ConceptTree({ triples, onSelect }: ConceptTreeProps) {
+  const [tree, setTree] = useState<Tree>({});
+
+  useEffect(() => {
+    const build = async () => {
+      if (triples.length === 0) {
+        setTree({});
+        return;
+      }
+      const store = new Store(triples);
+      const engine = new QueryEngine();
+      const query = `PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+        SELECT ?child ?parent WHERE {
+          ?child skos:broader ?parent .
+        }`;
+      try {
+        const result = await engine.queryBindings(query, { sources: [store] });
+        const bindings = await result.toArray();
+        const children: Tree = {};
+        for (const b of bindings) {
+          const child = b.get('child')!.value;
+          const parent = b.get('parent')!.value;
+          if (!children[parent]) children[parent] = [];
+          children[parent].push(child);
+          if (!children[child]) children[child] = [];
+        }
+        setTree(children);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    build();
+  }, [triples]);
+
+  const roots = Object.keys(tree).filter(
+    (iri) => !Object.values(tree).some((kids) => kids.includes(iri))
+  );
+
+  const renderNode = (iri: string) => (
+    <li key={iri}>
+      <button type="button" onClick={() => onSelect?.(iri)}>
+        {iri}
+      </button>
+      {tree[iri] && tree[iri].length > 0 && (
+        <ul>
+          {tree[iri].map((c) => renderNode(c))}
+        </ul>
+      )}
+    </li>
+  );
+
+  if (roots.length === 0) return null;
+
+  return (
+    <div data-testid="concept-tree">
+      <h2>Concepts</h2>
+      <ul>
+        {roots.map((r) => renderNode(r))}
+      </ul>
+    </div>
+  );
+}
+

--- a/app/src/TripleVisualization.tsx
+++ b/app/src/TripleVisualization.tsx
@@ -3,11 +3,13 @@ import type { Quad } from '@rdfjs/types';
 interface TripleVisualizationProps {
   triples: Quad[];
   onTripleClick?: (triple: Quad) => void;
+  focusNode?: string;
 }
 
 export default function TripleVisualization({
   triples,
   onTripleClick,
+  focusNode,
 }: TripleVisualizationProps) {
   const nodeIds = Array.from(
     new Set(triples.flatMap((t) => [t.subject.value, t.object.value]))
@@ -57,7 +59,13 @@ export default function TripleVisualization({
         ))}
         {nodes.map((n) => (
           <g key={n.id}>
-            <circle cx={n.x} cy={n.y} r={20} fill="white" stroke="black" />
+            <circle
+              cx={n.x}
+              cy={n.y}
+              r={20}
+              fill={n.id === focusNode ? 'yellow' : 'white'}
+              stroke="black"
+            />
             <text
               x={n.x}
               y={n.y}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
 
   app:
     dependencies:
+      '@comunica/query-sparql':
+        specifier: ^4.3.0
+        version: 4.3.0
       firebase:
         specifier: ^12.1.0
         version: 12.1.0


### PR DESCRIPTION
## Summary
- render SKOS concept hierarchy with new `ConceptTree`
- highlight nodes in `TripleVisualization`
- wire concept selection into form and graph

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a606afb1e08325bb1d3694e2a77467