### PR TITLE
Document home page note visualization and insertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Semantic, AI‑assisted ontology building for OWL and SKOS.
 
 These capabilities must remain supported when extending the codebase.
 
+The starting page always displays all saved notes as an RDF graph and a tree view
+for navigation, and it includes a form to insert new notes. Future changes
+should preserve this combination of visualization, navigation and input on the
+home page.
+
 This project is a proof‑of‑concept for a client‑side web application that lets you
 create and manage ontologies and vocabularies using OWL and SKOS. Annotations are
 recorded as RDF triples using annotation or note properties. A pluggable reasoning layer provides basic RDFS/SHACL checks and

--- a/SPECS.md
+++ b/SPECS.md
@@ -7,6 +7,8 @@
 - Add annotations through RDF triples using dedicated annotation properties.
 - Import/export TriG datasets as whole or per-graph; exports include a manifest recording each named graph’s IRI, type, and checksum. `scripts/import-dataset.ts` validates and merges data while enforcing SHACL and SPARQL invariants.
 - AI assistance (local-first) provides label suggestions, natural language to SPARQL drafts and mapping hints.
+- The home page shows all existing notes with both an RDF graph visualization and a
+  tree view for navigation, and includes a form for inserting new notes.
 
 ## Non-functional
 


### PR DESCRIPTION
## Summary
- Clarify that the home page visualizes existing notes, offers tree navigation, and provides a form to insert new notes
- Add functional spec requiring home page to retain visualization, navigation, and note input

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7a3066bf08325b613bbe4f3bd85da