### PR TITLE
test: cover home page navigation and input

### DIFF
--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -187,6 +187,30 @@ describe('App', () => {
     expect(subjectOptions.querySelector('option[value="ex:S2"]')).toBeFalsy();
   });
 
+  it('displays navigation tree alongside note input form on the home page', async () => {
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    );
+
+    const subjectInput = screen.getByLabelText(/subject/i);
+    const predicateInput = screen.getByLabelText(/predicate/i);
+    const objectInput = screen.getByLabelText(/^object$/i);
+
+    await userEvent.type(subjectInput, 'ex:Nav');
+    await userEvent.type(predicateInput, 'skos:broader');
+    await userEvent.type(objectInput, 'ex:Parent');
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    const tree = await screen.findByTestId('concept-tree');
+    expect(within(tree).getByRole('button', { name: 'ex:Nav' })).toBeTruthy();
+
+    expect(screen.getByLabelText(/subject/i)).toBeTruthy();
+    expect(screen.getByLabelText(/predicate/i)).toBeTruthy();
+    expect(screen.getByLabelText(/^object$/i)).toBeTruthy();
+  });
+
   it('renders concept tree and selects concepts', async () => {
     render(
       <MemoryRouter>


### PR DESCRIPTION
## Summary
- add test confirming the home page shows both note navigation tree and input form

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7a439eb1c83258d6e5d972771273c