### PR TITLE
feat: allow selecting triple object type

### DIFF
--- a/app/src/App.test.tsx
+++ b/app/src/App.test.tsx
@@ -40,6 +40,28 @@ describe('App', () => {
     expect(viz.textContent).toContain('ex:Object');
   });
 
+  it('allows selecting literal object type', async () => {
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    );
+
+    const subjectInput = screen.getByLabelText(/subject/i);
+    const predicateInput = screen.getByLabelText(/predicate/i);
+    const objectInput = screen.getByLabelText(/^object$/i);
+    const objectType = screen.getByLabelText(/object type/i) as HTMLSelectElement;
+
+    await userEvent.type(subjectInput, 'ex:S');
+    await userEvent.type(predicateInput, 'ex:p');
+    await userEvent.type(objectInput, 'Literal value');
+    await userEvent.selectOptions(objectType, 'literal');
+    await userEvent.click(screen.getByRole('button', { name: /(save|update)/i }));
+
+    expect(screen.getByTitle('Use object').textContent).toBe('Literal value');
+    expect(screen.getByText('(Literal)')).toBeTruthy();
+  });
+
   it('expands known namespace prefixes when saving triples', async () => {
     render(
       <MemoryRouter>
@@ -96,6 +118,7 @@ describe('App', () => {
     expect(screen.getByLabelText(/subject/i).getAttribute('title')).toBeTruthy();
     expect(screen.getByLabelText(/predicate/i).getAttribute('title')).toBeTruthy();
     expect(screen.getByLabelText(/^object$/i).getAttribute('title')).toBeTruthy();
+    expect(screen.getByLabelText(/object type/i).getAttribute('title')).toBeTruthy();
   });
 
   it('prefills form fields when triple parts are clicked', async () => {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -25,6 +25,8 @@ function Home() {
   const [subject, setSubject] = useState('');
   const [predicate, setPredicate] = useState('');
   const [object, setObject] = useState('');
+  type ObjectType = 'class' | 'literal';
+  const [objectType, setObjectType] = useState<ObjectType>('class');
   const [error, setError] = useState('');
   interface TripleEntry {
     id: string;
@@ -59,11 +61,12 @@ function Home() {
     setError('');
     const expandedSubject = expandCurie(subject);
     const expandedPredicate = expandCurie(predicate);
-    const expandedObject = expandCurie(object);
-    const objectTerm =
-      expandedObject !== object || /^https?:/.test(expandedObject) || object.includes(':')
-        ? namedNode(expandedObject)
-        : literal(object);
+    let objectTerm;
+    if (objectType === 'class') {
+      objectTerm = namedNode(expandCurie(object));
+    } else {
+      objectTerm = literal(object);
+    }
     const newQuad = createQuad(
       namedNode(expandedSubject),
       namedNode(expandedPredicate),
@@ -112,12 +115,14 @@ function Home() {
     setSubject('');
     setPredicate('');
     setObject('');
+    setObjectType('class');
   };
 
   const prefillFromTriple = (triple: Quad) => {
     setSubject(triple.subject.value);
     setPredicate(triple.predicate.value);
     setObject(triple.object.value);
+    setObjectType(triple.object.termType === 'NamedNode' ? 'class' : 'literal');
   };
 
   const handleDelete = async (id: string) => {
@@ -207,6 +212,17 @@ function Home() {
               ))}
             </datalist>
           </label>
+          <label>
+            Object Type
+            <select
+              value={objectType}
+              onChange={(e) => setObjectType(e.target.value as ObjectType)}
+              title="Select if the object is a class IRI or a literal value"
+            >
+              <option value="class">Class</option>
+              <option value="literal">Literal</option>
+            </select>
+          </label>
           <button type="submit">{editingId ? 'Update' : 'Save'}</button>
           {editingId && (
             <button
@@ -216,6 +232,7 @@ function Home() {
                 setSubject('');
                 setPredicate('');
                 setObject('');
+                setObjectType('class');
                 setError('');
               }}
             >


### PR DESCRIPTION
## Summary
- allow choosing class or literal for triple objects via dropdown
- handle object term creation based on selected type
- cover literal selection with new tests and update tooltip coverage

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7ca05e6848325840ea1a23d1bf299